### PR TITLE
Make flat and postgres optional, add optional store

### DIFF
--- a/id.cabal
+++ b/id.cabal
@@ -4,6 +4,22 @@ name:                id
 version:             0.1.0.0
 license-file:        LICENSE
 
+
+Flag postgres
+  Description: Enable Postgresql support
+  Default:     True
+  Manual:      False
+
+Flag flat
+  Description: Enable Flat serialization support
+  Default:     True
+  Manual:      False
+
+Flag store
+  Description: Enable Data.Store serialization support
+  Default:     False
+  Manual:      False
+
 library
   exposed-modules:
     Data.Id
@@ -14,7 +30,6 @@ library
     base >=4.12 && <5,
     binary,
     deepseq,
-    flat,
     hashable,
     http-api-data,
     lens,
@@ -23,10 +38,22 @@ library
     text,
     QuickCheck,
     uuid,
+  if flag(postgres) && !impl(ghcjs)
+    build-depends:
+      postgresql-simple
+    cpp-options: -DUSE_POSTGRES
   if !impl(ghcjs)
     build-depends:
-      cassava,
-      postgresql-simple,
+      cassava
+  if flag(flat)
+    build-depends:
+      flat,
+    cpp-options: -DUSE_FLAT
+  if flag(store)
+    build-depends:
+      store,
+    cpp-options: -DUSE_STORE
+
   hs-source-dirs:
     src
   default-language:

--- a/id.cabal
+++ b/id.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                id
-version:             0.1.0.0
+version:             0.2.0.0
 license-file:        LICENSE
 
 Flag cassava

--- a/id.cabal
+++ b/id.cabal
@@ -4,6 +4,11 @@ name:                id
 version:             0.1.0.0
 license-file:        LICENSE
 
+Flag cassava
+  Description: Enable Postgresql support
+  Default:     True
+  Manual:      False
+
 
 Flag postgres
   Description: Enable Postgresql support
@@ -42,9 +47,10 @@ library
     build-depends:
       postgresql-simple
     cpp-options: -DUSE_POSTGRES
-  if !impl(ghcjs)
+  if flag(cassava) && !impl(ghcjs)
     build-depends:
       cassava
+    cpp-options: -DUSE_CASSAVA
   if flag(flat)
     build-depends:
       flat,

--- a/src/Data/Id.hs
+++ b/src/Data/Id.hs
@@ -25,7 +25,9 @@ import           Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID.V4
 #ifndef ghcjs_HOST_OS
+#ifdef USE_CASSAVA
 import           Data.Csv as Csv hiding(Name)
+#endif
 #ifdef USE_POSTGRES
 import           Database.PostgreSQL.Simple.FromField as PG (FromField)
 import           Database.PostgreSQL.Simple.ToField as PG (ToField)
@@ -102,12 +104,14 @@ instance PathPiece (Id t) where
 
 #ifndef ghcjs_HOST_OS
 
+#ifdef USE_CASSAVA
 instance Csv.FromField (Id tag) where
   parseField = parseField
     >=> fmap mkId . maybe (fail "invalid UUID in CSV") pure . UUID.fromText
 
 instance Csv.ToField (Id tag) where
   toField = Csv.toField . UUID.toText . coerce
+#endif
 
 #endif
 
@@ -135,7 +139,10 @@ newtype IntId t = IntId { unIntId :: Integer }
   ( Eq, Ord, Binary
 #ifndef ghcjs_HOST_OS
 #ifdef USE_POSTGRES
-  , PG.ToField, PG.FromField, Csv.ToField, Csv.FromField
+  , PG.ToField, PG.FromField
+#endif
+#ifdef USE_CASSAVA
+  , Csv.ToField, Csv.FromField
 #endif
 #endif
   , FromJSON, ToJSON, NFData, Hashable, FromJSONKey, ToJSONKey, ToSchema
@@ -175,7 +182,10 @@ newtype Name t = Name { unName :: Text }
   ( Eq, Ord, Binary
 #ifndef ghcjs_HOST_OS
 #ifdef USE_POSTGRES
-  , PG.ToField, PG.FromField, Csv.ToField, Csv.FromField
+  , PG.ToField, PG.FromField
+#endif
+#ifdef USE_CASSAVA
+  , Csv.ToField, Csv.FromField
 #endif
 #endif
   , FromJSON, ToJSON, NFData, Hashable, FromJSONKey, ToJSONKey, ToSchema

--- a/src/Data/Id.hs
+++ b/src/Data/Id.hs
@@ -25,23 +25,32 @@ import           Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID.V4
 #ifndef ghcjs_HOST_OS
+import           Data.Csv as Csv hiding(Name)
+#ifdef USE_POSTGRES
 import           Database.PostgreSQL.Simple.FromField as PG (FromField)
 import           Database.PostgreSQL.Simple.ToField as PG (ToField)
-import           Data.Csv as Csv hiding(Name)
 #endif
-import           Flat as F
+#endif
 import           GHC.TypeLits
 import           Test.QuickCheck
 import           Text.ParserCombinators.ReadP
 import           Web.HttpApiData
 import           Web.PathPieces (PathPiece(..))
+#ifdef USE_FLAT
+import           Flat as F
+#endif
+#ifdef USE_STORE
+import qualified Data.Store
+#endif
 
 newtype Id t = Id { unId :: UUID }
   deriving stock Data
   deriving newtype
   ( Eq, Ord, Binary
 #ifndef ghcjs_HOST_OS
+#ifdef USE_POSTGRES
   , PG.ToField, PG.FromField
+#endif
 #endif
   , FromJSON, ToJSON, NFData, Hashable, FromJSONKey, ToJSONKey, ToSchema
   , ToParamSchema, FromHttpApiData, ToHttpApiData )
@@ -66,10 +75,19 @@ instance KnownSymbol s => Read (Id s) where
     _ <- string ("Id-" <> symbolVal (Proxy @s) <> "-")
     mkId <$> readS_to_P reads
 
+#ifdef USE_FLAT
 instance Flat (Id s) where
   encode = F.encode . UUID.toWords . coerce
   decode = coerce . (\(a,b,c,d) -> UUID.fromWords a b c d) <$> F.decode
   size = F.size . UUID.toWords . coerce
+#endif
+
+#ifdef USE_STORE
+instance Data.Store.Store (Id s) where
+  poke = Data.Store.poke . UUID.toWords . coerce
+  peek = coerce . (\(a,b,c,d) -> UUID.fromWords a b c d) <$> Data.Store.peek
+  size = Data.Store.ConstSize 16
+#endif
 
 instance Arbitrary (Id t) where
   arbitrary = fmap Id $ UUID.fromWords
@@ -116,7 +134,9 @@ newtype IntId t = IntId { unIntId :: Integer }
   deriving newtype
   ( Eq, Ord, Binary
 #ifndef ghcjs_HOST_OS
+#ifdef USE_POSTGRES
   , PG.ToField, PG.FromField, Csv.ToField, Csv.FromField
+#endif
 #endif
   , FromJSON, ToJSON, NFData, Hashable, FromJSONKey, ToJSONKey, ToSchema
   , ToParamSchema, FromHttpApiData, ToHttpApiData, PathPiece, Flat, Arbitrary
@@ -154,7 +174,9 @@ newtype Name t = Name { unName :: Text }
   deriving newtype
   ( Eq, Ord, Binary
 #ifndef ghcjs_HOST_OS
+#ifdef USE_POSTGRES
   , PG.ToField, PG.FromField, Csv.ToField, Csv.FromField
+#endif
 #endif
   , FromJSON, ToJSON, NFData, Hashable, FromJSONKey, ToJSONKey, ToSchema
   , ToParamSchema, FromHttpApiData, ToHttpApiData, PathPiece, Flat


### PR DESCRIPTION
This makes postgres and flat optional and adds optional store.

Sometimes store is more convenient for serialization and the postgres bit is just to make this compile faster when I work with it occasionally.