### PR TITLE
Dependency bounds

### DIFF
--- a/id.cabal
+++ b/id.cabal
@@ -25,10 +25,9 @@ flag store
 
 library
   exposed-modules:    Data.Id
-
   build-depends:
-    , aeson
-    , base           >=4.12 && <5
+    , aeson          >=1.0
+    , base           >=4.12  && <5
     , binary
     , deepseq
     , hashable
@@ -36,7 +35,7 @@ library
     , lens
     , path-pieces
     , text
-    , uuid
+    , uuid           >=1.3.9
 
   if !(impl(ghcjs) || arch(javascript))
     build-depends:
@@ -54,7 +53,7 @@ library
     cpp-options:   -DUSE_CASSAVA
 
   if flag(flat)
-    build-depends: flat
+    build-depends: flat >=0.4
     cpp-options:   -DUSE_FLAT
 
   if flag(store)

--- a/id.cabal
+++ b/id.cabal
@@ -1,72 +1,68 @@
-cabal-version:       2.4
+cabal-version: 2.4
+name:          id
+version:       0.2.0.0
+license-file:  LICENSE
 
-name:                id
-version:             0.2.0.0
-license-file:        LICENSE
+flag cassava
+  description: Enable Postgresql support
+  default:     True
+  manual:      False
 
-Flag cassava
-  Description: Enable Postgresql support
-  Default:     True
-  Manual:      False
+flag postgres
+  description: Enable Postgresql support
+  default:     True
+  manual:      False
 
+flag flat
+  description: Enable Flat serialization support
+  default:     True
+  manual:      False
 
-Flag postgres
-  Description: Enable Postgresql support
-  Default:     True
-  Manual:      False
-
-Flag flat
-  Description: Enable Flat serialization support
-  Default:     True
-  Manual:      False
-
-Flag store
-  Description: Enable Data.Store serialization support
-  Default:     False
-  Manual:      False
+flag store
+  description: Enable Data.Store serialization support
+  default:     False
+  manual:      False
 
 library
-  exposed-modules:
-    Data.Id
-  -- other-modules:
-  -- other-extensions:
+  exposed-modules:    Data.Id
+
   build-depends:
-    aeson,
-    base >=4.12 && <5,
-    binary,
-    deepseq,
-    hashable,
-    http-api-data,
-    lens,
-    path-pieces,
-    text,
-    uuid,
+    , aeson
+    , base           >=4.12 && <5
+    , binary
+    , deepseq
+    , hashable
+    , http-api-data
+    , lens
+    , path-pieces
+    , text
+    , uuid
+
   if !(impl(ghcjs) || arch(javascript))
     build-depends:
-        openapi3
+      , openapi3
       , QuickCheck
-    cpp-options: -DBACKEND
-  if flag(postgres) && !(impl(ghcjs) || arch(javascript))
-    build-depends:
-      postgresql-simple
-    cpp-options: -DUSE_POSTGRES
-  if flag(cassava) && !(impl(ghcjs) || arch(javascript))
-    build-depends:
-      cassava
-    cpp-options: -DUSE_CASSAVA
-  if flag(flat)
-    build-depends:
-      flat,
-    cpp-options: -DUSE_FLAT
-  if flag(store)
-    build-depends:
-      store,
-    cpp-options: -DUSE_STORE
 
-  hs-source-dirs:
-    src
-  default-language:
-    Haskell2010
+    cpp-options:   -DBACKEND
+
+  if (flag(postgres) && !(impl(ghcjs) || arch(javascript)))
+    build-depends: postgresql-simple
+    cpp-options:   -DUSE_POSTGRES
+
+  if (flag(cassava) && !(impl(ghcjs) || arch(javascript)))
+    build-depends: cassava
+    cpp-options:   -DUSE_CASSAVA
+
+  if flag(flat)
+    build-depends: flat
+    cpp-options:   -DUSE_FLAT
+
+  if flag(store)
+    build-depends: store
+    cpp-options:   -DUSE_STORE
+
+  hs-source-dirs:     src
+  default-language:   Haskell2010
   default-extensions:
     AllowAmbiguousTypes
     DeriveGeneric


### PR DESCRIPTION
- `aeson >=1.0` for `FromJSONKey`/`ToJSONKey`
- `uuid >=1.3.9` because earlier versions of the package defined their own UUID type instead of re-exporting from `uuid-types`, and `FromJSON`/`ToJSON` instances are only defined on the type from `uuid-types`.
- `flat >=0.4` because the module name changed from `Data.Flat` to `Flat`