### PR TITLE
Remove the backend/frontend divide

### DIFF
--- a/id.cabal
+++ b/id.cabal
@@ -33,16 +33,11 @@ library
     , hashable
     , http-api-data
     , lens
+    , openapi3
     , path-pieces
+    , QuickCheck
     , text
     , uuid           >=1.3.9
-
-  if !(impl(ghcjs) || arch(javascript))
-    build-depends:
-      , openapi3
-      , QuickCheck
-
-    cpp-options:   -DBACKEND
 
   if (flag(postgres) && !(impl(ghcjs) || arch(javascript)))
     build-depends: postgresql-simple


### PR DESCRIPTION
It was only gating `ToSchema` and `Arbitrary` instances.

The API packages are usually used by both backend and frontend, and they usually need to use the `ToSchema` instance.