### PR TITLE
Use uuid-types

### DIFF
--- a/id.cabal
+++ b/id.cabal
@@ -23,6 +23,12 @@ flag store
   default:     False
   manual:      False
 
+flag uuid-impl
+  description: Include some functions with extra dependencies.
+               Disable to reduce dependencies.
+  default:     True
+  manual:      False
+
 library
   exposed-modules:    Data.Id
   build-depends:
@@ -35,7 +41,11 @@ library
     , lens
     , path-pieces
     , text
-    , uuid           >=1.3.9
+    , uuid-types
+  if flag(uuid-impl)
+    build-depends:
+      , uuid >=1.3.9
+    cpp-options:   -DUSE_UUID
 
   if !(impl(ghcjs) || arch(javascript) || arch(wasm32))
     build-depends:

--- a/src/Data/Id.hs
+++ b/src/Data/Id.hs
@@ -4,9 +4,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Data.Id
-  ( Id, mkId, unId, randomId, unsafeIdTagConvert, coerceId, _Id, nilId
+  ( Id, mkId, unId, unsafeIdTagConvert, coerceId, _Id, nilId
   , IntId, mkIntId, unIntId, unsafeIntIdTagConvert, coerceIntId, _IntId
   , Name, mkName, unName, unsafeNameTagConvert, coerceName, _Name
+#ifdef USE_UUID
+  , randomId
+#endif
   )
   where
 
@@ -20,15 +23,17 @@ import           Data.Data
 import           Data.Hashable (Hashable)
 import           Data.String
 import           Data.Text as T
-import           Data.UUID (UUID)
-import qualified Data.UUID as UUID
-import qualified Data.UUID.V4 as UUID.V4
+import           Data.UUID.Types (UUID)
+import qualified Data.UUID.Types as UUID
 import           GHC.TypeLits
 import           Prelude as P
 import           Text.ParserCombinators.ReadP
 import           Web.HttpApiData
 import           Web.PathPieces (PathPiece(..))
 
+#ifdef USE_UUID
+import qualified Data.UUID.V4 as UUID.V4
+#endif
 #ifdef BACKEND
 import           Data.OpenApi
 import           Test.QuickCheck
@@ -71,9 +76,11 @@ mkId :: forall s. UUID -> Id s
 mkId = coerce
 {-# INLINE mkId #-}
 
+#ifdef USE_UUID
 randomId :: forall s. IO (Id s)
 randomId = coerce <$> UUID.V4.nextRandom
 {-# INLINE randomId #-}
+#endif
 
 instance KnownSymbol s => Show (Id s) where
   show (Id v) = "Id-" <> symbolVal (Proxy @s) <> "-" <> P.show v


### PR DESCRIPTION
Package `uuid` include many dependencies which are not needed in many cases (especially on frontend). So here I use `uuid-types` and hide `uuid` under flag `uuid-impl`. This flag is enabled by default so we keep compatibility.  